### PR TITLE
Upgrade ace version to 1.2.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "graphviz-d3-renderer": "0.9.23",
-    "ace": "1.1.9",
+    "ace": "1.2.6",
     "pouchdb": "~5.4.0",
     "bootstrap": "3.3.2",
     "grapnel": "~0.6.2"


### PR DESCRIPTION
There were input problems in putting CJK text on the editor.

<img width="707" alt="screen shot 2017-02-09 at 5 45 19 pm" src="https://cloud.githubusercontent.com/assets/7418482/22775873/e20a4f60-eef0-11e6-8a09-4381cfae4bcb.png">

I've found just versioning up the editor solves the input problem.

<img width="1030" alt="screen shot 2017-02-09 at 5 45 38 pm" src="https://cloud.githubusercontent.com/assets/7418482/22775861/ce79bb34-eef0-11e6-83ea-a9d12def9c47.png">
